### PR TITLE
Resolved Issue 2 and implemented feature 1 - Display Greeting Only With Name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/.idea/vcs.xml

--- a/app/src/main/java/edu/temple/helloworld/MainActivity.kt
+++ b/app/src/main/java/edu/temple/helloworld/MainActivity.kt
@@ -20,9 +20,13 @@ class MainActivity : AppCompatActivity() {
 
         
         findViewById<Button>(R.id.clickMeButton).setOnClickListener {
-            displayTextView.text = "Hello, ${findViewById<EditText>(R.id.nameEditText).text}"
+            // To track what was entered in editText
+            val name = findViewById<EditText>(R.id.nameEditText).text
+            if (name.toString() == "") {
+                displayTextView.text = "Error, please enter a name in the field before clicking button"
+            } else {
+                displayTextView.text = "Hello, ${name}"
+            }
         }
-
-
     }
 }


### PR DESCRIPTION
Error message is displayed if button clicked without any name entered. Greeting isn't displayed anymore when editText is empty.